### PR TITLE
Fix default value $opt for curl_getinfo(resource $ch [, int $opt = 0]).

### DIFF
--- a/src/CurlHttpClient.php
+++ b/src/CurlHttpClient.php
@@ -358,7 +358,11 @@ class CurlHttpClient
 	 */
 	public function getInfo ($opt = 0)
 	{
-		return curl_getinfo($this->ch, $opt);
+		if ($opt === 0) {
+			return curl_getinfo($this->ch);
+		} else {
+			return curl_getinfo($this->ch, $opt);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If you pass a value of $opt=0 curl_getinfo returns FALSE, but must return a list of all parameters.
Test for:
- php 5.4.45
- php 5.5.29
- php 5.6.13
